### PR TITLE
Update math.py and ray_trainer.py to fix issues caused by update to codebase

### DIFF
--- a/examples/reward_function/math.py
+++ b/examples/reward_function/math.py
@@ -29,12 +29,15 @@ def accuracy_reward(predict: str, ground_truth: str) -> float:
     return 1.0 if grade_answer(answer, ground_truth) else 0.0
 
 
-def compute_score(predicts: List[str], ground_truths: List[str], format_weight: float = 0.1) -> List[Dict[str, float]]:
+def compute_score(reward_inputs: list[dict[str, Any]], format_weight: float = 0.1) -> list[dict[str, float]]:
+    if not isinstance(reward_inputs, list):
+        raise ValueError("Please use `reward_type=batch` for math reward function.")
+
     scores = []
-    for predict, ground_truth in zip(predicts, ground_truths):
-        predict = re.sub(r"\s*(<|>|/)\s*", r"\1", predict)  # handle qwen2.5vl-32b format
-        format_score = format_reward(predict)
-        accuracy_score = accuracy_reward(predict, ground_truth)
+    for reward_input in reward_inputs:
+        response = re.sub(r"\s*(<|>|/)\s*", r"\1", reward_input["response"])  # handle qwen2.5vl-32b format
+        format_score = format_reward(response)
+        accuracy_score = accuracy_reward(response, reward_input["ground_truth"])
         scores.append(
             {
                 "overall": (1 - format_weight) * accuracy_score + format_weight * format_score,

--- a/examples/reward_function/math.py
+++ b/examples/reward_function/math.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import re
-from typing import Dict, List
+from typing import Any
 
 from mathruler.grader import extract_boxed_content, grade_answer
 

--- a/verl/trainer/ray_trainer.py
+++ b/verl/trainer/ray_trainer.py
@@ -501,7 +501,14 @@ class RayPPOTrainer:
         if self.config.algorithm.contrastive_type == "augmented":
             augmented_images = []
             for img in original_images_pil:
-                aug_img = random_patch_blackening(img, **aug_config)
+                if isinstance(img, dict) and 'bytes' in img:
+                        from io import BytesIO
+                        img_bytes = img['bytes']
+                        stream = BytesIO(img_bytes)
+                        pil_img = Image.open(stream) 
+                        aug_img = random_patch_blackening(pil_img, **aug_config)
+                else:
+                    aug_img = random_patch_blackening(img, **aug_config)
                 augmented_images.append(aug_img)
             return augmented_images
         else:


### PR DESCRIPTION
There were two issues:
1. We forgot to update math.py to reflect the change that we were now passing `reward_inputs` rather than `reponse_str` and `ground_truths` like before. To fix the issue, I copied the code EASYR1 had.
2. Currently `original_images_pil` is a list of dicts with keys {'bytes', 'path'} rather than list of PIL images. Consequently, a dict rather than a PIL image is being passed into ` random_patch_blackening`. This causes the code to crash. To fix the issue, I just extracted the bytes from the dictionary and converted the bytes to a PIL image.